### PR TITLE
Added protection for identifiers containing unicode characters

### DIFF
--- a/src/oaipmh/common.py
+++ b/src/oaipmh/common.py
@@ -6,7 +6,10 @@ class Header(object):
     def __init__(self, identifier, datestamp, setspec, deleted):
         # force identifier to be a string, it might be 
         # an lxml.etree._ElementStringResult...
-        self._identifier = str(identifier)
+        try:
+            self._identifier = str(identifier)
+        except UnicodeEncodeError:
+            self._identifier = unicode(identifier)
         self._datestamp = datestamp
         self._setspec = setspec
         self._deleted = deleted


### PR DESCRIPTION
Hi,

Thanks for maintaining this library, it's been really useful - just what I was looking for! However, when I was harvesting archival records, the client threw an exception because a record's identifier field contained a non-ascii character.

When processing the OAI header, there is a call to str() to ensure that the identifier field is converted to a string. However, when the indentifier contains non-ascii characters a UnicodeEncodeError was being thrown. Since this was being thrown in the record iteration, it was not possible to handle this exception in client code.

This commit catches that exception and calls unicode() instead. I could have used unicode() in the ordinary case, but didn't know whether this would cause problems in the rest of the library.

Hope the patch is of use,

Kind regards,

Charles
