### PR TITLE
Do not resume the request if no result was returned.

### DIFF
--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -338,9 +338,11 @@ def buildHeader(header_node, namespaces):
 def ResumptionListGenerator(firstBatch, nextBatch):
     result, token = firstBatch()
     while 1:
+        itemFound = False
         for item in result:
             yield item
-        if token is None:
+            itemFound = True
+        if token is None or not itemFound:
             break
         result, token = nextBatch(token)
 


### PR DESCRIPTION
Some OAI-PMH servers provide a resumption token even when there are no further results. For instance, such a behaviour can be observed on this endpoint: http://api-preprod.archives-ouvertes.fr/oai/hal/
(I suggest to use a very short time frame to reduce the number of results. For instance, `verb=ListRecords&from=2002-12-30&metadataPrefix=oai_dc&until=2003-01-06`)

In this case, the current code enters an infinite loop. This patch fixes the problem.
