### PR TITLE
Option to use HTTP GET requests instead of POST

### DIFF
--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -301,10 +301,11 @@ class BaseClient(common.OAIPMH):
 
 class Client(BaseClient):
     def __init__(
-            self, base_url, metadata_registry=None, credentials=None, local_file=False):
+            self, base_url, metadata_registry=None, credentials=None, local_file=False, http_get=False):
         BaseClient.__init__(self, metadata_registry)
         self._base_url = base_url
         self._local_file = local_file
+        self._http_get = http_get
         if credentials is not None:
             self._credentials = base64.encodestring('%s:%s' % credentials)
         else:
@@ -322,8 +323,13 @@ class Client(BaseClient):
             headers = {'User-Agent': 'pyoai'}
             if self._credentials is not None:
                 headers['Authorization'] = 'Basic ' + self._credentials.strip()
-            request = urllib2.Request(
-                self._base_url, data=urlencode(kw), headers=headers)
+            if self._http_get:
+                request_url = '%s?%s' % (self._base_url, urlencode(kw))
+                request = urllib2.Request(request_url, headers=headers)
+            else:
+                request = urllib2.Request(
+                    self._base_url, data=urlencode(kw), headers=headers)
+
             return retrieveFromUrlWaiting(request)
 
 def buildHeader(header_node, namespaces):

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -301,11 +301,11 @@ class BaseClient(common.OAIPMH):
 
 class Client(BaseClient):
     def __init__(
-            self, base_url, metadata_registry=None, credentials=None, local_file=False, http_get=False):
+            self, base_url, metadata_registry=None, credentials=None, local_file=False, force_http_get=False):
         BaseClient.__init__(self, metadata_registry)
         self._base_url = base_url
         self._local_file = local_file
-        self._http_get = http_get
+        self._force_http_get = force_http_get
         if credentials is not None:
             self._credentials = base64.encodestring('%s:%s' % credentials)
         else:
@@ -323,7 +323,7 @@ class Client(BaseClient):
             headers = {'User-Agent': 'pyoai'}
             if self._credentials is not None:
                 headers['Authorization'] = 'Basic ' + self._credentials.strip()
-            if self._http_get:
+            if self._force_http_get:
                 request_url = '%s?%s' % (self._base_url, urlencode(kw))
                 request = urllib2.Request(request_url, headers=headers)
             else:


### PR DESCRIPTION
This changed adds a new option to the Client contructor called
`http_get`, which is a boolean defaulting to False.

If this option is set to True, the Client would construct a URL for a
HTTP GET request instead of the otherwise used POST request (determined
if a caller provides the `data` parameter or not). According to the
OAI-PMH standard both methods are allowed. But I came across yet
another faulty implementation, where POST would not work, only GET does.
This flag is a workaround that might come in handy for others as well.