### PR TITLE
Fix slicing the result in BatchingResumption.

### DIFF
--- a/src/oaipmh/server.py
+++ b/src/oaipmh/server.py
@@ -423,16 +423,16 @@ class BatchingResumption(common.ResumptionOAIPMH):
             kw['batch_size'] = self._batch_size + 1  
             result = method(**kw)
             result = list(result)
-            if len(result) > self._batch_size:
+            if len(result) > cursor + self._batch_size:
                 # more results are expected, so encode resumption token
                 resumptionToken = encodeResumptionToken(
                     kw, cursor + self._batch_size)
-                # we also want to result only the batch_size, so pop the
-                # last one
-                result.pop()
+                cursor_end = cursor + self._batch_size
             else:
                 # no more results are expected
                 resumptionToken = None
+                cursor_end = len(result)
+            result = result[cursor:cursor_end]
             return result, resumptionToken
         return method(**kw)
     


### PR DESCRIPTION
Slicing the result sets bigger than batch_size wasn't working. BatchingResumption class always returned the full result set. This fixes it. Fix also takes care that we don't go out of the result set.