### PR TITLE
Fix python3 syntax issues in unit tests

### DIFF
--- a/src/oaipmh/tests/createbrokendata.py
+++ b/src/oaipmh/tests/createbrokendata.py
@@ -1,4 +1,4 @@
-from fakeclient import FakeCreaterClient
+from .fakeclient import FakeCreaterClient
 from datetime import datetime
 from oaipmh import metadata
 
@@ -20,55 +20,55 @@ client = FakeCreaterClient(
 #print "isDeleted:", header.isDeleted()
 #print
 
-print "Identify"
+print("Identify")
 identify = client.identify()
-print "repositoryName:", identify.repositoryName()
-print "baseURL:", identify.baseURL()
-print "protocolVerson:", identify.protocolVersion()
-print "adminEmails:", identify.adminEmails()
-print "earliestDatestamp:", identify.earliestDatestamp()
-print "deletedRecords:", identify.deletedRecord()
-print "granularity:", identify.granularity()
-print "compression:", identify.compression()
-print
+print("repositoryName:", identify.repositoryName())
+print("baseURL:", identify.baseURL())
+print("protocolVerson:", identify.protocolVersion())
+print("adminEmails:", identify.adminEmails())
+print("earliestDatestamp:", identify.earliestDatestamp())
+print("deletedRecords:", identify.deletedRecord())
+print("granularity:", identify.granularity())
+print("compression:", identify.compression())
+print()
 
-print "ListIdentifiers"
-headers = client.listIdentifiers(from_=datetime(2006, 02, 8),
+print("ListIdentifiers")
+headers = client.listIdentifiers(from_=datetime(2006, 2, 8),
                                  metadataPrefix='oai_dc')
 for header in headers:
-    print "identifier:", header.identifier()
-    print "datestamp:", header.datestamp()
-    print "setSpec:", header.setSpec()
-    print "isDeleted:", header.isDeleted()
-print
+    print("identifier:", header.identifier())
+    print("datestamp:", header.datestamp())
+    print("setSpec:", header.setSpec())
+    print("isDeleted:", header.isDeleted())
+print()
 
-print "ListMetadataFormats"
+print("ListMetadataFormats")
 for prefix, schema, ns in client.listMetadataFormats():
-    print "metadataPrefix:", prefix
-    print "schema:", schema
-    print "metadataNamespace:", ns
-print
+    print("metadataPrefix:", prefix)
+    print("schema:", schema)
+    print("metadataNamespace:", ns)
+print()
 
-print "ListRecords"
+print("ListRecords")
 for header, metadata, about in client.listRecords(
-    from_=datetime(2006, 02, 8), metadataPrefix='oai_dc'):
-    print "header"
-    print "identifier:", header.identifier()
-    print "datestamp:", header.datestamp()
-    print "setSpec:", header.setSpec()
-    print "isDeleted:", header.isDeleted()
+    from_=datetime(2006, 2, 8), metadataPrefix='oai_dc'):
+    print("header")
+    print("identifier:", header.identifier())
+    print("datestamp:", header.datestamp())
+    print("setSpec:", header.setSpec())
+    print("isDeleted:", header.isDeleted())
     #print "metadata"
     #for fieldname in fieldnames:
     #    print "%s:" % fieldname, metadata.getField(fieldname)
-    print "about"
-    print about
-print
+    print("about")
+    print(about)
+print()
 
-print "ListSets"
+print("ListSets")
 for setSpec, setName, setDescription in client.listSets():
-    print "setSpec:", setSpec
-    print "setName:", setName
-    print "setDescription:", setDescription
-print
+    print("setSpec:", setSpec)
+    print("setName:", setName)
+    print("setDescription:", setDescription)
+print()
 
 client.save()

--- a/src/oaipmh/tests/createdata.py
+++ b/src/oaipmh/tests/createdata.py
@@ -1,68 +1,68 @@
-from fakeclient import FakeCreaterClient
+from .fakeclient import FakeCreaterClient
 
 # tied to the server at EUR..
 client = FakeCreaterClient(
     'http://dspace.ubib.eur.nl/oai/',
     '/home/faassen/py/oai/tests/fake2')
 
-print "GetRecord"
+print("GetRecord")
 header, metadata, about = client.getRecord(
     metadataPrefix='oai_dc', identifier='hdl:1765/315')
-print "identifier:", header.identifier()
-print "datestamp:", header.datestamp()
-print "setSpec:", header.setSpec()
-print "isDeleted:", header.isDeleted()
-print
+print("identifier:", header.identifier())
+print("datestamp:", header.datestamp())
+print("setSpec:", header.setSpec())
+print("isDeleted:", header.isDeleted())
+print()
 
-print "Identify"
+print("Identify")
 identify = client.identify()
-print "repositoryName:", identify.repositoryName()
-print "baseURL:", identify.baseURL()
-print "protocolVerson:", identify.protocolVersion()
-print "adminEmails:", identify.adminEmails()
-print "earliestDatestamp:", identify.earliestDatestamp()
-print "deletedRecords:", identify.deletedRecord()
-print "granularity:", identify.granularity()
-print "compression:", identify.compression()
-print
+print("repositoryName:", identify.repositoryName())
+print("baseURL:", identify.baseURL())
+print("protocolVerson:", identify.protocolVersion())
+print("adminEmails:", identify.adminEmails())
+print("earliestDatestamp:", identify.earliestDatestamp())
+print("deletedRecords:", identify.deletedRecord())
+print("granularity:", identify.granularity())
+print("compression:", identify.compression())
+print()
 
-print "ListIdentifiers"
-headers = client.listIdentifiers(from_=datetime(2003, 04, 10),
+print("ListIdentifiers")
+headers = client.listIdentifiers(from_=datetime(2003, 4, 10),
                                  metadataPrefix='oai_dc')
 for header in headers:
-    print "identifier:", header.identifier()
-    print "datestamp:", header.datestamp()
-    print "setSpec:", header.setSpec()
-    print "isDeleted:", header.isDeleted()
-print
+    print("identifier:", header.identifier())
+    print("datestamp:", header.datestamp())
+    print("setSpec:", header.setSpec())
+    print("isDeleted:", header.isDeleted())
+print()
 
-print "ListMetadataFormats"
+print("ListMetadataFormats")
 for prefix, schema, ns in client.listMetadataFormats():
-    print "metadataPrefix:", prefix
-    print "schema:", schema
-    print "metadataNamespace:", ns
-print
+    print("metadataPrefix:", prefix)
+    print("schema:", schema)
+    print("metadataNamespace:", ns)
+print()
 
-print "ListRecords"
+print("ListRecords")
 for header, metadata, about in client.listRecords(
-    from_=datetime(2003, 04, 10), metadataPrefix='oai_dc'):
-    print "header"
-    print "identifier:", header.identifier()
-    print "datestamp:", header.datestamp()
-    print "setSpec:", header.setSpec()
-    print "isDeleted:", header.isDeleted()
+    from_=datetime(2003, 4, 10), metadataPrefix='oai_dc'):
+    print("header")
+    print("identifier:", header.identifier())
+    print("datestamp:", header.datestamp())
+    print("setSpec:", header.setSpec())
+    print("isDeleted:", header.isDeleted())
     #print "metadata"
     #for fieldname in fieldnames:
     #    print "%s:" % fieldname, metadata.getField(fieldname)
-    print "about"
-    print about
-print
+    print("about")
+    print(about)
+print()
 
-print "ListSets"
+print("ListSets")
 for setSpec, setName, setDescription in client.listSets():
-    print "setSpec:", setSpec
-    print "setName:", setName
-    print "setDescription:", setDescription
-print
+    print("setSpec:", setSpec)
+    print("setName:", setName)
+    print("setDescription:", setDescription)
+print()
 
 client.save()

--- a/src/oaipmh/tests/createdata_deleted_records.py
+++ b/src/oaipmh/tests/createdata_deleted_records.py
@@ -1,4 +1,4 @@
-from fakeserver import FakeCreaterServerProxy
+from .fakeserver import FakeCreaterServerProxy
 
 # tied to the server at EUR..
 server = FakeCreaterServerProxy(
@@ -6,40 +6,40 @@ server = FakeCreaterServerProxy(
     '/home/eric/CVS_checkouts/oai/tests/fake2')
 
 #deleted record
-print "GetRecord"
+print("GetRecord")
 header, metadata, about = server.getRecord(
     metadataPrefix='oai_dc', identifier='hdl:1765/1160')
-print "identifier:", header.identifier()
-print "datestamp:", header.datestamp()
-print "setSpec:", header.setSpec()
-print "isDeleted:", header.isDeleted()
-print
+print("identifier:", header.identifier())
+print("datestamp:", header.datestamp())
+print("setSpec:", header.setSpec())
+print("isDeleted:", header.isDeleted())
+print()
 
 #normal record
-print "GetRecord"
+print("GetRecord")
 header, metadata, about = server.getRecord(
     metadataPrefix='oai_dc', identifier='hdl:1765/1162')
-print "identifier:", header.identifier()
-print "datestamp:", header.datestamp()
-print "setSpec:", header.setSpec()
-print "isDeleted:", header.isDeleted()
-print
+print("identifier:", header.identifier())
+print("datestamp:", header.datestamp())
+print("setSpec:", header.setSpec())
+print("isDeleted:", header.isDeleted())
+print()
 
-print "ListRecords"
+print("ListRecords")
 for header, metadata, about in server.listRecords(
-    from_=datetime(2004, 01, 01), until=datetime(2004, 02, 01),
+    from_=datetime(2004, 1, 1), until=datetime(2004, 2, 1),
     metadataPrefix='oai_dc'):
-    print "header"
-    print "identifier:", header.identifier()
-    print "datestamp:", header.datestamp()
-    print "setSpec:", header.setSpec()
-    print "isDeleted:", header.isDeleted()
-    print "metadata"
+    print("header")
+    print("identifier:", header.identifier())
+    print("datestamp:", header.datestamp())
+    print("setSpec:", header.setSpec())
+    print("isDeleted:", header.isDeleted())
+    print("metadata")
     if metadata is not None:
         for fieldname in metadata.getMap().keys():
-            print "%s:" % fieldname, metadata.getField(fieldname)
-    print "about"
-    print about
-print
+            print("%s:" % fieldname, metadata.getField(fieldname))
+    print("about")
+    print(about)
+print()
 
 server.save()

--- a/src/oaipmh/tests/fakeclient.py
+++ b/src/oaipmh/tests/fakeclient.py
@@ -1,8 +1,7 @@
 from oaipmh import client, common
 import os.path
 from datetime import datetime
-from urllib import urlencode
-from string import zfill
+from urllib.parse import urlencode
 
 class FakeClient(client.BaseClient):
     def __init__(self, mapping_path):
@@ -39,7 +38,7 @@ class GranularityFakeClient(client.BaseClient):
 def getRequestKey(kw):
     """Create stable key for request dictionary to use in file.
     """
-    items = kw.items()
+    items = list(kw.items())
     items.sort()
     return urlencode(items)
 
@@ -66,7 +65,7 @@ class FakeCreaterClient(client.Client):
         self._mapping_path = mapping_path
         
     def makeRequest(self, **kw):
-        print kw
+        print(kw)
         text = client.Client.makeRequest(self, **kw)
         self._mapping[getRequestKey(kw)] = text
         return text
@@ -78,7 +77,7 @@ class FakeCreaterClient(client.Client):
         for request, response in self._mapping.items():
             f.write(request)
             f.write('\n')
-            filename = zfill(str(i), 5) + '.xml'
+            filename = str(i).zfill(5) + '.xml'
             f.write(filename)
             f.write('\n')
             response_f = open(os.path.join(mapping_path, filename), 'w')

--- a/src/oaipmh/tests/fakeserver.py
+++ b/src/oaipmh/tests/fakeserver.py
@@ -18,7 +18,7 @@ class FakeServerCommon(object):
         try:
             return self._data[int(identifier)]
         except IndexError:
-            raise error.IdDoesNotExistError, "Id does not exist: %s" % identifier
+            raise error.IdDoesNotExistError("Id does not exist: %s" % identifier)
 
 class FakeServerBase(FakeServerCommon):
     

--- a/src/oaipmh/tests/test_client.py
+++ b/src/oaipmh/tests/test_client.py
@@ -16,71 +16,71 @@ class ClientTestCase(TestCase):
     def test_getRecord(self):
         header, metadata, about = fakeclient.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assertEquals(
+        self.assertEqual(
             'hdl:1765/315',
             header.identifier())
-        self.assertEquals(
+        self.assertEqual(
             ['2:7'],
             header.setSpec())
-        self.assert_(not header.isDeleted())
+        self.assertTrue(not header.isDeleted())
         
     def test_getMetadata(self):
         metadata = fakeclient.getMetadata(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assertEquals(metadata.tag,
+        self.assertEqual(metadata.tag,
                           '{http://www.openarchives.org/OAI/2.0/oai_dc/}dc')
 
         
     def test_identify(self):
         identify = fakeclient.identify()
-        self.assertEquals(
+        self.assertEqual(
             'Erasmus University : Research Online',
             identify.repositoryName())
-        self.assertEquals(
+        self.assertEqual(
             'http://dspace.ubib.eur.nl/oai/',
             identify.baseURL())
-        self.assertEquals(
+        self.assertEqual(
             '2.0',
             identify.protocolVersion())
-        self.assertEquals(
+        self.assertEqual(
             ['service@ubib.eur.nl'],
             identify.adminEmails())
-        self.assertEquals(
+        self.assertEqual(
             'no',
             identify.deletedRecord())
-        self.assertEquals(
+        self.assertEqual(
             'YYYY-MM-DDThh:mm:ssZ',
             identify.granularity())
-        self.assertEquals(
+        self.assertEqual(
             ['gzip', 'compress', 'deflate'],
             identify.compression())
 
     def test_listIdentifiers(self):
-        headers = fakeclient.listIdentifiers(from_=datetime(2003, 04, 10),
+        headers = fakeclient.listIdentifiers(from_=datetime(2003, 0o4, 10),
                                              metadataPrefix='oai_dc')
         # lazy, just test first one
         headers = list(headers)
         
         header = headers[0]
-        self.assertEquals(
+        self.assertEqual(
             'hdl:1765/308',
             header.identifier())
-        self.assertEquals(
+        self.assertEqual(
             datetime(2003, 4, 15, 10, 18, 51),
             header.datestamp())
-        self.assertEquals(
+        self.assertEqual(
             ['1:2'],
             header.setSpec())
-        self.assert_(not header.isDeleted())
-        self.assertEquals(16, len(headers))
+        self.assertTrue(not header.isDeleted())
+        self.assertEqual(16, len(headers))
 
 
     def test_listIdentifiers_until_none(self):
         # test listIdentifiers with until argument as None explicitly
-        headers = fakeclient.listIdentifiers(from_=datetime(2003, 04, 10),
+        headers = fakeclient.listIdentifiers(from_=datetime(2003, 0o4, 10),
                                              until=None,
                                              metadataPrefix='oai_dc')
-        self.assertEquals(16, len(list(headers)))
+        self.assertEqual(16, len(list(headers)))
 
     def test_listIdentifiers_from_none(self):
         # test listIdentifiers with until argument as None explicitly
@@ -91,8 +91,8 @@ class ClientTestCase(TestCase):
         try:
             headers = fakeclient.listIdentifiers(from_=None,
                                                  metadataPrefix='oai_dc')
-        except KeyError, e:
-            self.assertEquals('metadataPrefix=oai_dc&verb=ListIdentifiers',
+        except KeyError as e:
+            self.assertEqual('metadataPrefix=oai_dc&verb=ListIdentifiers',
                               e.args[0])
             
     def test_listIdentifiers_argument_error(self):
@@ -102,36 +102,36 @@ class ClientTestCase(TestCase):
             foo='bar')
         
     def test_listRecords(self):
-        records = fakeclient.listRecords(from_=datetime(2003, 04, 10),
+        records = fakeclient.listRecords(from_=datetime(2003, 0o4, 10),
                                          metadataPrefix='oai_dc')
         records = list(records)
         # lazy, just test first one
         header, metadata, about = records[0]
-        self.assertEquals(
+        self.assertEqual(
             'hdl:1765/308',
             header.identifier())
-        self.assertEquals(
+        self.assertEqual(
             datetime(2003, 4, 15, 10, 18, 51),
              header.datestamp())
-        self.assertEquals(
+        self.assertEqual(
             ['1:2'],
             header.setSpec())
-        self.assert_(not header.isDeleted())
+        self.assertTrue(not header.isDeleted())
         # XXX need to extend metadata tests
-        self.assertEquals(
+        self.assertEqual(
             ['Kijken in het brein: Over de mogelijkheden van neuromarketing'],
             metadata.getField('title'))
             
     def test_listMetadataFormats(self):
         formats = fakeclient.listMetadataFormats()
         metadataPrefix, schema, metadataNamespace = formats[0]
-        self.assertEquals(
+        self.assertEqual(
             'oai_dc',
             metadataPrefix)
-        self.assertEquals(
+        self.assertEqual(
             'http://www.openarchives.org/OAI/2.0/oai_dc.xsd',
             schema)
-        self.assertEquals(
+        self.assertEqual(
             'http://www.openarchives.org/OAI/2.0/oai_dc/',
             metadataNamespace)
 
@@ -144,7 +144,7 @@ class ClientTestCase(TestCase):
         sets = fakeclient.listSets()
         sets = list(sets)
         compare = [sets[0], sets[1]]
-        self.assertEquals(
+        self.assertEqual(
             expected,
             compare)
 
@@ -152,19 +152,19 @@ class ClientTestCase(TestCase):
         fakeclient = GranularityFakeClient(granularity='YYYY-MM-DDThh:mm:ssZ')
         fakeclient.updateGranularity()
         try:
-            fakeclient.listRecords(from_=datetime(2003, 04, 10, 14, 0),
+            fakeclient.listRecords(from_=datetime(2003, 0o4, 10, 14, 0),
                                    metadataPrefix='oai_dc')
-        except TestError, e:
-            self.assertEquals('2003-04-10T14:00:00Z', e.kw['from'])
+        except TestError as e:
+            self.assertEqual('2003-04-10T14:00:00Z', e.kw['from'])
         fakeclient = GranularityFakeClient(granularity='YYYY-MM-DD')
         fakeclient.updateGranularity()
         try:
-            fakeclient.listRecords(from_=datetime(2003, 04, 10, 14, 0),
-                                   until=datetime(2004, 06, 17, 15, 30),
+            fakeclient.listRecords(from_=datetime(2003, 0o4, 10, 14, 0),
+                                   until=datetime(2004, 0o6, 17, 15, 30),
                                    metadataPrefix='oai_dc')
-        except TestError, e:
-            self.assertEquals('2003-04-10', e.kw['from'])
-            self.assertEquals('2004-06-17', e.kw['until'])
+        except TestError as e:
+            self.assertEqual('2003-04-10', e.kw['from'])
+            self.assertEqual('2004-06-17', e.kw['until'])
             
 def test_suite():
     return TestSuite((makeSuite(ClientTestCase), ))

--- a/src/oaipmh/tests/test_datestamp.py
+++ b/src/oaipmh/tests/test_datestamp.py
@@ -6,13 +6,13 @@ from oaipmh.error import DatestampError
 
 class DatestampTestCase(TestCase):
     def test_strict_datestamp_to_datetime(self):
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4, 14, 35, 10),
             datestamp_to_datetime('2005-07-04T14:35:10Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 1, 24, 14, 34, 2),
             datestamp_to_datetime('2005-01-24T14:34:02Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4),
             datestamp_to_datetime('2005-07-04'))
         self.assertRaises(DatestampError,
@@ -33,33 +33,33 @@ class DatestampTestCase(TestCase):
                           datestamp_to_datetime, 'foo')
         try:
             datestamp_to_datetime('foo')
-        except DatestampError, e:
-            self.assertEquals('foo', e.datestamp)
+        except DatestampError as e:
+            self.assertEqual('foo', e.datestamp)
 
     def test_strict_datestamp_to_datetime_inclusive(self):
         # passing inclusive=True to datestamp_to_datetime
         # should default the time to 23:59:59 instead of 00:00:00
         # when only a date is supplied
 
-        self.assertEquals(datetime(2009, 11, 16, 23, 59, 59),
+        self.assertEqual(datetime(2009, 11, 16, 23, 59, 59),
                           datestamp_to_datetime('2009-11-16',
                                                 inclusive=True))
         
     def test_tolerant_datestamp_to_datetime(self):
         f = tolerant_datestamp_to_datetime
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4, 14, 35, 10),
             f('2005-07-04T14:35:10Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 1, 24, 14, 34, 2),
             f('2005-01-24T14:34:02Z'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 7, 4),
             f('2005-07-04'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 1, 1),
             f('2005'))
-        self.assertEquals(
+        self.assertEqual(
             datetime(2005, 2, 1),
             f('2005-02'))
         

--- a/src/oaipmh/tests/test_deleted_records.py
+++ b/src/oaipmh/tests/test_deleted_records.py
@@ -15,24 +15,24 @@ class DeletedRecordsTestCase(TestCase):
     def test_getRecord_deleted(self):
         header, metadata, about = fakeclient.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/1160')
-        self.assert_(metadata is None)
-        self.assert_(header.isDeleted())
+        self.assertTrue(metadata is None)
+        self.assertTrue(header.isDeleted())
 
     def test_getRecord_not_deleted(self):
         header, metadata, about = fakeclient.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/1162')
-        self.assert_(metadata is not None)
-        self.assert_(not header.isDeleted())
+        self.assertTrue(metadata is not None)
+        self.assertTrue(not header.isDeleted())
 
     def test_listRecords(self):
-        records = fakeclient.listRecords(from_=datetime(2004, 01, 01),
+        records = fakeclient.listRecords(from_=datetime(2004, 0o1, 0o1),
                                          metadataPrefix='oai_dc')
         # lazy, just test first one
         for header, metadata, about in records:
             if header.isDeleted():
-                self.assert_(metadata is None)
+                self.assertTrue(metadata is None)
             else:
-                self.assert_(metadata is not None)
+                self.assertTrue(metadata is not None)
     
 def test_suite():
     return TestSuite((makeSuite(DeletedRecordsTestCase), ))

--- a/src/oaipmh/tests/test_server.py
+++ b/src/oaipmh/tests/test_server.py
@@ -1,11 +1,11 @@
 import unittest
 import os
-from StringIO import StringIO
+from io import StringIO
 from oaipmh import server, client, common, metadata, error
 from lxml import etree
 from datetime import datetime
-import fakeclient
-import fakeserver
+from . import fakeclient
+from . import fakeserver
 
 NS_OAIPMH = server.NS_OAIPMH
 
@@ -33,37 +33,37 @@ class XMLTreeServerTestCase(unittest.TestCase):
     def test_getRecord(self):
         tree = self._server.getRecord(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_getMetadata(self):
         tree = self._server.getMetadata(
             metadataPrefix='oai_dc', identifier='hdl:1765/315')
-        self.assertEquals(tree.tag,
+        self.assertEqual(tree.tag,
                           '{http://www.openarchives.org/OAI/2.0/oai_dc/}dc')
         
     def test_identify(self):
         tree = self._server.identify()
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_listIdentifiers(self):
         tree = self._server.listIdentifiers(
             from_=datetime(2003, 4, 10),
             metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         
     def test_listMetadataFormats(self):
         tree = self._server.listMetadataFormats()
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_listRecords(self):
         tree = self._server.listRecords(
             from_=datetime(2003, 4, 10),
             metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_listSets(self):
         tree = self._server.listSets()
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
 
     def test_namespaceDeclarations(self):
         # according to the spec, all namespace used in the metadata
@@ -109,14 +109,14 @@ class ServerTestCase(unittest.TestCase):
     def test_identify(self):
         xml = self._server.identify()
         tree = etree.parse(StringIO(xml))
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         
     def test_listIdentifiers(self):
         xml = self._server.listIdentifiers(
-            from_=datetime(2003, 04, 10),
+            from_=datetime(2003, 0o4, 10),
             metadataPrefix='oai_dc')
         tree = etree.parse(StringIO(xml))
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         
 class ResumptionTestCase(unittest.TestCase):
     def setUp(self):
@@ -130,7 +130,7 @@ class ResumptionTestCase(unittest.TestCase):
         while token is not None:
             result, token = self._server.listIdentifiers(resumptionToken=token)
             headers.extend(result)
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in headers])
 
     def test_tree_resumption(self):
@@ -139,9 +139,9 @@ class ResumptionTestCase(unittest.TestCase):
         myserver = server.XMLTreeServer(
             self._server, metadata_registry)
         tree = myserver.listIdentifiers(metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         # we should find a resumptionToken element with text
-        self.assert_(
+        self.assertTrue(
             tree.xpath('//oai:resumptionToken/text()', 
                        namespaces={'oai': NS_OAIPMH} ))
         
@@ -155,14 +155,14 @@ class BatchingResumptionTestCase(unittest.TestCase):
         result, token = resumption_server.listIdentifiers(
             metadataPrefix='oai_dc')
         headers.extend(result)
-        self.assert_(token is not None)
+        self.assertTrue(token is not None)
         while token is not None:
-            self.assert_(result)
-            self.assertEquals(expected_length, len(result))
+            self.assertTrue(result)
+            self.assertEqual(expected_length, len(result))
             result, token = resumption_server.listIdentifiers(
                 resumptionToken=token)
             headers.extend(result)
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in headers])
 
     def test_resumption(self):
@@ -176,8 +176,8 @@ class BatchingResumptionTestCase(unittest.TestCase):
         myserver = server.BatchingResumption(self._fakeserver, 300)
         result, token = myserver.listIdentifiers(
             metadataPrefix='oai_dc')
-        self.assert_(token is None)
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertTrue(token is None)
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in result])
         
     def test_tree_resumption(self):
@@ -185,9 +185,9 @@ class BatchingResumptionTestCase(unittest.TestCase):
         metadata_registry.registerWriter('oai_dc', server.oai_dc_writer)
         myserver = server.XMLTreeServer(self._server, metadata_registry)
         tree = myserver.listIdentifiers(metadataPrefix='oai_dc')
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         # we should find a resumptionToken element with text
-        self.assert_(
+        self.assertTrue(
             tree.xpath('//oai:resumptionToken/text()', 
                        namespaces={'oai': NS_OAIPMH} ))
         
@@ -203,19 +203,19 @@ class ClientServerTestCase(unittest.TestCase):
 
     def test_listIdentifiers(self):
         headers = self._client.listIdentifiers(metadataPrefix='oai_dc')
-        self.assertEquals([str(i) for i in range(100)],
+        self.assertEqual([str(i) for i in range(100)],
                           [header.identifier() for header in headers])
 
     def test_listRecords(self):
         records = self._client.listRecords(metadataPrefix='oai_dc')
         records = list(records)
-        self.assertEquals(100, len(records))
+        self.assertEqual(100, len(records))
         metadatas = [metadata for (header, metadata, about) in records]
         result = []
         for metadata in metadatas:
             result.append(metadata.getField('title')[0])
         expected = ['Title %s' % i for i in range(100)]
-        self.assertEquals(expected, result)
+        self.assertEqual(expected, result)
         #for record in records:
         #    print record[0].datestamp()
 
@@ -225,7 +225,7 @@ class ClientServerTestCase(unittest.TestCase):
                                                until=datetime(2004, 7, 1))
         # we expect 52 items
         headers = list(headers)
-        self.assertEquals(52, len(headers))
+        self.assertEqual(52, len(headers))
 
     def test_listIdentifiersFromUntil_nothing(self):
         self.assertRaises(error.NoRecordsMatchError,
@@ -313,13 +313,13 @@ class ErrorTestCase(unittest.TestCase):
         
     
     def assertErrors(self, errors, xml):
-        self.assertEquals(errors, self.findErrors(xml))
+        self.assertEqual(errors, self.findErrors(xml))
         
     def findErrors(self, xml):
         # parse
         tree = etree.parse(StringIO(xml))
         # validate xml
-        self.assert_(oaischema.validate(tree))
+        self.assertTrue(oaischema.validate(tree))
         result = []
         for e in tree.xpath(
             '//oai:error', namespaces={'oai': NS_OAIPMH}):
@@ -341,31 +341,31 @@ class DeletionTestCase(unittest.TestCase):
         headers = self._client.listIdentifiers(metadataPrefix='oai_dc')
         # we expect 12 items
         headers = list(headers)
-        self.assertEquals(12, len(headers))
+        self.assertEqual(12, len(headers))
         # now delete
         self._fakeserver.deletionEvent()
         # check again, we expect 12 items, but half of which is deleted
         headers = self._client.listIdentifiers(metadataPrefix='oai_dc')
         headers = list(headers)
-        self.assertEquals(12, len(headers))
+        self.assertEqual(12, len(headers))
         deleted_count = 0
         for header in headers:
             if header.isDeleted():
                 deleted_count += 1
-        self.assertEquals(6, deleted_count)
+        self.assertEqual(6, deleted_count)
 
     def test_listRecords(self):
         self._fakeserver.deletionEvent()
         # we expect 12 items, but half of which is deleted
         records = self._client.listRecords(metadataPrefix='oai_dc')
         records = list(records)
-        self.assertEquals(12, len(records))
+        self.assertEqual(12, len(records))
         deleted_count = 0
         for header, metadata, about in records:
             if header.isDeleted():
                 deleted_count += 1
-                self.assertEquals(None, metadata)
-        self.assertEquals(6, deleted_count)
+                self.assertEqual(None, metadata)
+        self.assertEqual(6, deleted_count)
 
     def test_getRecord(self):
         self._fakeserver.deletionEvent()
@@ -375,8 +375,8 @@ class DeletionTestCase(unittest.TestCase):
         # we try to access a deleted record
         header, metadata, about = self._client.getRecord(
             metadataPrefix='oai_dc', identifier='1')
-        self.assert_(header.isDeleted())
-        self.assertEquals(None, metadata)
+        self.assertTrue(header.isDeleted())
+        self.assertEqual(None, metadata)
 
 class NsMapTestCase(unittest.TestCase):
     def setUp(self):
@@ -397,7 +397,7 @@ class NsMapTestCase(unittest.TestCase):
         # if we pass another nsmap along to the server constructor, we
         # can control extra namespaces in the output envelope
         tree = self._xmlserver.identify()
-        self.assertEquals(
+        self.assertEqual(
             'http://www.cow.com',
             tree.getroot().nsmap['cow'])
         

--- a/src/oaipmh/tests/test_validation.py
+++ b/src/oaipmh/tests/test_validation.py
@@ -7,7 +7,7 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             'foo': 'optional',
             'bar': 'optional'
             }
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo', 'bar': 'Bar'}))
         # an extra argument gives an error
@@ -16,10 +16,10 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             validation.validate,
             spec, {'hoi': 'Hoi', 'foo': 'Foo', 'bar': 'Bar'})
         # a missing optional argument is fine
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo'}))
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {}))
 
@@ -27,10 +27,10 @@ class ArgumentValidatorTestCase(unittest.TestCase):
         spec = {
             'foo': 'required',
             'bar': 'optional'}
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo', 'bar': 'Bar'}))
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo'}))
         self.assertRaises(
@@ -42,7 +42,7 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             'foo': 'required',
             'bar': 'required',
             'hoi': 'exclusive'}
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'foo': 'Foo', 'bar': 'Bar'}))
         self.assertRaises(
@@ -52,7 +52,7 @@ class ArgumentValidatorTestCase(unittest.TestCase):
             validation.BadArgumentError,
             validation.validate, spec, {'bar': 'Bar'})
         # or a single exclusive argument
-        self.assertEquals(
+        self.assertEqual(
             None,
             validation.validate(spec, {'hoi': 'Hoi'}))
         self.assertRaises(


### PR DESCRIPTION
This adds more compatibility fixes for python3 in the unit test scripts.
Please note that more fixes are required to actually *pass* the unit tests.

@infrae 
If possible, please consider merging https://github.com/infrae/pyoai/pull/17 - after you do that, I can work more on Py3 compatibility