### PR TITLE
allow customization of "retry" policy.

### DIFF
--- a/doc/API.txt
+++ b/doc/API.txt
@@ -314,6 +314,27 @@ a coarse way to control how many items are read before stopping. If
 the amount of items exceeds ``max`` after reading a resumptionToken,
 the method will halt.
 
+retry policy
+------------
+
+When the harvested OAI server returns an HTTP 503, the default policy is to
+retry 5 times and wait 120 seconds between each try. Due to the variety of OAI
+server implementations, one might want to configure those parameters. This
+policy can be customized through the ``BaseClient.custom_retry_policy``'s
+parameter. For instance::
+
+    >>> client = Client('http://the-oai-base-url.org', custom_retry_policy={
+            # retry on both 500 and 503 HTTP return codes
+            'expected-errcodes': {500, 503},
+            # wait for 30 seconds before retrying
+            'wait-default': 30,
+            # retry 10 times
+            'retry': 10,
+        })
+)
+
+
+
 .. _OAI-PMH protocol: http://www.openarchives.org/OAI/openarchivesprotocol.html
 
 .. _Protocol Requests and Responses: http://www.openarchives.org/OAI/openarchivesprotocol.html#ProtocolMessages

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -27,13 +27,27 @@ WAIT_MAX = 5
 class Error(Exception):
     pass
 
-class BaseClient(common.OAIPMH):
 
-    def __init__(self, metadata_registry=None):
+class BaseClient(common.OAIPMH):
+    # retry policy on error. Default is to retry request `WAIT_MAX` times
+    # on HTTP 503 errors, waiting `WAIT_DEFAULT` before each retry
+    default_retry_policy = {
+        # how many seconds should we wait before each retry
+        'wait-default': WAIT_DEFAULT,
+        # how many times should we retry
+        'retry': WAIT_MAX,
+        # which HTTP codes are expected
+        'expected-errcodes': {503},
+    }
+
+    def __init__(self, metadata_registry=None, custom_retry_policy=None):
         self._metadata_registry = (
             metadata_registry or metadata.global_metadata_registry)
         self._ignore_bad_character_hack = 0
         self._day_granularity = False
+        self.retry_policy = self.default_retry_policy.copy()
+        if custom_retry_policy is not None:
+            self.retry_policy.update(custom_retry_policy)
 
     def updateGranularity(self):
         """Update the granularity setting dependent on that the server says.
@@ -249,7 +263,7 @@ class BaseClient(common.OAIPMH):
         # first find resumption token is available
         token = evaluator.evaluate(
             'string(/oai:OAI-PMH/*/oai:resumptionToken/text())')
-            #'string(/oai:OAI-PMH/oai:ListIdentifiers/oai:resumptionToken/text())')
+        #'string(/oai:OAI-PMH/oai:ListIdentifiers/oai:resumptionToken/text())')
         if token.strip() == '':
             token = None
         header_nodes = evaluator.evaluate(
@@ -312,9 +326,11 @@ class BaseClient(common.OAIPMH):
         raise NotImplementedError
 
 class Client(BaseClient):
-    def __init__(
-            self, base_url, metadata_registry=None, credentials=None, local_file=False, force_http_get=False):
-        BaseClient.__init__(self, metadata_registry)
+
+    def __init__(self, base_url, metadata_registry=None, credentials=None,
+                 local_file=False, force_http_get=False, custom_retry_policy=None):
+        BaseClient.__init__(self, metadata_registry,
+                            custom_retry_policy=custom_retry_policy)
         self._base_url = base_url
         self._local_file = local_file
         self._force_http_get = force_http_get
@@ -343,7 +359,12 @@ class Client(BaseClient):
                 request = urllib2.Request(
                     self._base_url, data=binary_data, headers=headers)
 
-            return retrieveFromUrlWaiting(request)
+            return retrieveFromUrlWaiting(
+                request,
+                wait_max=self.retry_policy['retry'],
+                wait_default=self.retry_policy['wait-default'],
+                expected_errcodes=self.retry_policy['expected-errcodes']
+            )
 
 def buildHeader(header_node, namespaces):
     e = etree.XPathEvaluator(header_node,
@@ -365,7 +386,8 @@ def ResumptionListGenerator(firstBatch, nextBatch):
         result, token = nextBatch(token)
 
 def retrieveFromUrlWaiting(request,
-                           wait_max=WAIT_MAX, wait_default=WAIT_DEFAULT):
+                           wait_max=WAIT_MAX, wait_default=WAIT_DEFAULT,
+                           expected_errcodes={503}):
     """Get text from URL, handling 503 Retry-After.
     """
     for i in list(range(wait_max)):
@@ -375,9 +397,8 @@ def retrieveFromUrlWaiting(request,
             f.close()
             # we successfully opened without having to wait
             break
-        except urllib2.HTTPError:
-            e = sys.exc_info()[1]
-            if e.code == 503:
+        except urllib2.HTTPError as e:
+            if e.code in expected_errcodes:
                 try:
                     retryAfter = int(e.hdrs.get('Retry-After'))
                 except TypeError:

--- a/src/oaipmh/tests/fakeclient.py
+++ b/src/oaipmh/tests/fakeclient.py
@@ -8,10 +8,10 @@ except ImportError:
 
 
 class FakeClient(client.BaseClient):
-    def __init__(self, mapping_path):
-        client.BaseClient.__init__(self)
+    def __init__(self, mapping_path, custom_retry_policy=None):
+        client.BaseClient.__init__(self, custom_retry_policy=custom_retry_policy)
         self._mapping = createMapping(mapping_path)
-        
+
     def makeRequest(self, **kw):
         # this is a complete fake, and can only deal with a number of
         # fixed requests that are mapped to files
@@ -21,12 +21,12 @@ class FakeClient(client.BaseClient):
 class TestError(Exception):
     def __init__(self, kw):
         self.kw = kw
-        
+
 class GranularityFakeClient(client.BaseClient):
     def __init__(self, granularity):
         client.BaseClient.__init__(self)
         self._granularity = granularity
-        
+
     def makeRequest(self, **kw):
         # even more fake, we'll simply raise an exception with the request
         # this can be caught by the test to see whether the request uses
@@ -67,7 +67,7 @@ class FakeCreaterClient(client.Client):
         client.Client.__init__(self, base_url, metadata_registry)
         self._mapping = {}
         self._mapping_path = mapping_path
-        
+
     def makeRequest(self, **kw):
         text = client.Client.makeRequest(self, **kw)
         self._mapping[getRequestKey(kw)] = text

--- a/tox.ini
+++ b/tox.ini
@@ -4,3 +4,7 @@ envlist = py{27,33,34,35,36}
 [testenv]
 changedir = src/oaipmh/tests
 commands = ./runtests.sh
+
+[testenv:py27]
+deps =
+    mock


### PR DESCRIPTION
When the harvested OAI server returns an HTTP 503, the default policy is to
retry 5 times and wait 120 seconds between each try. Due to the variety of OAI
server implementations, one might want to configure those parameters. This
policy can be customized through the ``BaseClient.custom_retry_policy``'s
parameter. For instance::

    >>> client = Client('http://the-oai-base-url.org', custom_retry_policy={
            # retry on both 500 and 503 HTTP return codes
            'expected-errcodes': {500, 503},
            # wait for 30 seconds before retrying
            'wait-default': 30,
            # retry 10 times
            'retry': 10,
        })
)