### PR TITLE
add XMLparser recover option for client; keep default behavior same: recover=False

### DIFF
--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -40,7 +40,7 @@ class BaseClient(common.OAIPMH):
         'expected-errcodes': {503},
     }
 
-    def __init__(self, metadata_registry=None, custom_retry_policy=None):
+    def __init__(self, metadata_registry=None, custom_retry_policy=None, recover=False):
         self._metadata_registry = (
             metadata_registry or metadata.global_metadata_registry)
         self._ignore_bad_character_hack = 0
@@ -48,6 +48,7 @@ class BaseClient(common.OAIPMH):
         self.retry_policy = self.default_retry_policy.copy()
         if custom_retry_policy is not None:
             self.retry_policy.update(custom_retry_policy)
+        self.XMLParser = etree.XMLParser(recover=recover)
 
     def updateGranularity(self):
         """Update the granularity setting dependent on that the server says.
@@ -122,7 +123,7 @@ class BaseClient(common.OAIPMH):
             if hasattr(xml, "encode"):
                 xml = xml.encode("utf-8")
             # xml = xml.encode("utf-8")
-        return etree.XML(xml)
+        return etree.XML(xml, parser=self.XMLParser)
 
     # implementation of the various methods, delegated here by
     # handleVerb method
@@ -328,9 +329,10 @@ class BaseClient(common.OAIPMH):
 class Client(BaseClient):
 
     def __init__(self, base_url, metadata_registry=None, credentials=None,
-                 local_file=False, force_http_get=False, custom_retry_policy=None):
+                 local_file=False, force_http_get=False, custom_retry_policy=None,
+                 recover=False):
         BaseClient.__init__(self, metadata_registry,
-                            custom_retry_policy=custom_retry_policy)
+                            custom_retry_policy=custom_retry_policy, recover=recover)
         self._base_url = base_url
         self._local_file = local_file
         self._force_http_get = force_http_get


### PR DESCRIPTION
Adds an option in Client and BaseClient to use `recover=True` option on etree.XMLParser, so that OAI harvesting won't fail on a bad metadata payload. 
Default is `recover=False`, so that it doesn't change any existing behavior ( Making the conservative choice here, just in case anyone is relying on catching failures to validate feeds. )

Initially, I tried parsing first with recover=False, catching errors and then retrying with recover=True, but I discovered that was unnecessary. 
1. I though parsing with recover=True might be slower, but when there are no parser errors to recover from, I could not measure any time penalty for using that option.
2. I wanted to  complete the harvest, but I also wanted to catch and log errors so that I could notify upstream maintainers of the feed that there were issues to be fixed.  I discovered that self.XMLParser.error_log will contain any errors if they occur, and that lxml has a  facility to pass lxml errors to the Python logging error log module by calling tree.use_global_python_log(). Logging should be configured first before using that facility, so to enable, use something like this in the calling program:

```
from lxml import etree
import logging
etree.use_global_python_log(etree.PyErrorLog())
logging.basicConfig()
```

That will output a line like this, for example, on an unescaped ampersand:
`CRITICAL:root:<string>:47:219:FATAL:PARSER:ERR_ENTITYREF_SEMICOL_MISSING: EntityRef: expecting ';'`

lxml documents how that message can be changed or filtered, if for example, you want to change those 'CRITICAL' to 'WARNING' , but I didn't think that was worth adding to the base code if it's not already using logging module. 

