### PR TITLE
Add py37 test envs to tox and travis configs.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ python:
   - "3.4"
   - "3.5"
   - "3.6"
+  - "3.7"
 
 install:
   - pip install tox

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33,34,35,36}
+envlist = py{27,33,34,35,36,37}
 
 [testenv]
 changedir = src/oaipmh/tests


### PR DESCRIPTION
Hey all, just wanted to see if we could include the Python 3.7 envs for tox and Travis. No code changes needed (that I know of), just want to show that the code supports Python 3.7 as-is (based on the tests).