### PR TITLE
Fix imports for Python 3.8

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [2.7, 3.5, 3.6, 3.7]
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v1

--- a/src/oaipmh/server.py
+++ b/src/oaipmh/server.py
@@ -5,7 +5,11 @@ try:
     from urllib.parse import urlencode, quote, unquote
 except ImportError:
     from urllib import quote, unquote, urlencode
-import sys, cgi
+try:
+    from urllib.parse import parse_qs
+except ImportError:
+    from urlparse import parse_qs
+import sys
 
 from oaipmh import common, metadata, validation, error
 from oaipmh.datestamp import datestamp_to_datetime, datetime_to_datestamp, DatestampError
@@ -454,7 +458,7 @@ def decodeResumptionToken(token):
     token = str(unquote(token))
     
     try:
-        kw = cgi.parse_qs(token, True, True)
+        kw = parse_qs(token, True, True)
     except ValueError:
         raise error.BadResumptionTokenError(
               "Unable to decode resumption token: %s" % token)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,35,36,37}
+envlist = py{27,35,36,37,38}
 
 [gh-actions]
 python =
@@ -7,6 +7,7 @@ python =
     3.5: py35
     3.6: py36
     3.7: py37
+    3.8: py38
 
 [testenv]
 changedir = src/oaipmh/tests


### PR DESCRIPTION
Py38 removed `cgi.parse_qs` so instead use `urllib.parse.parse_qs` or `urlparse.parse_qs` for 2.7.

The tests pass.