### PR TITLE
Modify version number to be pep440 compatible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from os.path import join, dirname
 
 setup(
     name='pyoai',
-    version='2.5.1(unreleased)',
+    version='2.5.1pre',
     author='Infrae',
     author_email='info@infrae.com',
     url='http://www.infrae.com/download/oaipmh',


### PR DESCRIPTION
This had caused an issue when creating a `Pipfile.lock` using `pipenv`