### PR TITLE
python 3.13.7 support + raw data support

### DIFF
--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -147,15 +147,15 @@ class BaseClient(common.OAIPMH):
         )[0]
         e = identify_node.xpath
 
-        repositoryName = e('string(oai:repositoryName/text())')
-        baseURL = e('string(oai:baseURL/text())')
-        protocolVersion = e('string(oai:protocolVersion/text())')
-        adminEmails = e('oai:adminEmail/text()')
+        repositoryName = e('string(oai:repositoryName/text())', namespaces=namespaces)
+        baseURL = e('string(oai:baseURL/text())', namespaces=namespaces)
+        protocolVersion = e('string(oai:protocolVersion/text())', namespaces=namespaces)
+        adminEmails = e('oai:adminEmail/text()', namespaces=namespaces)
         earliestDatestamp = datestamp_to_datetime(
-            e('string(oai:earliestDatestamp/text())'))
-        deletedRecord = e('string(oai:deletedRecord/text())')
-        granularity = e('string(oai:granularity/text())')
-        compression = e('oai:compression/text()')
+            e('string(oai:earliestDatestamp/text())', namespaces=namespaces))
+        deletedRecord = e('string(oai:deletedRecord/text())', namespaces=namespaces)
+        granularity = e('string(oai:granularity/text())', namespaces=namespaces)
+        compression = e('oai:compression/text()', namespaces=namespaces)
         # XXX description
         identify = common.Identify(
             repositoryName, baseURL, protocolVersion,
@@ -182,9 +182,9 @@ class BaseClient(common.OAIPMH):
         metadataFormats = []
         for metadataFormat_node in metadataFormat_nodes:
             e = metadataFormat_node.xpath
-            metadataPrefix = e('string(oai:metadataPrefix/text())')
-            schema = e('string(oai:schema/text())')
-            metadataNamespace = e('string(oai:metadataNamespace/text())')
+            metadataPrefix = e('string(oai:metadataPrefix/text())', namespaces=namespaces)
+            schema = e('string(oai:schema/text())', namespaces=namespaces)
+            metadataNamespace = e('string(oai:metadataNamespace/text())', namespaces=namespaces)
             metadataFormat = (metadataPrefix, schema, metadataNamespace)
             metadataFormats.append(metadataFormat)
 
@@ -232,11 +232,11 @@ class BaseClient(common.OAIPMH):
         for record_node in record_nodes:
             e = record_node.xpath
             # find header node
-            header_node = e('oai:header')[0]
+            header_node = e('oai:header', namespaces=namespaces)[0]
             # create header
             header = buildHeader(header_node, namespaces)
             # find metadata node
-            metadata_list = e('oai:metadata')
+            metadata_list = e('oai:metadata', namespaces=namespaces)
             if metadata_list:
                 metadata_node = metadata_list[0]
                 # create metadata
@@ -282,8 +282,8 @@ class BaseClient(common.OAIPMH):
             e = set_node.xpath
             # make sure we get back unicode strings instead
             # of lxml.etree._ElementUnicodeResult objects.
-            setSpec = six.text_type(e('string(oai:setSpec/text())'))
-            setName = six.text_type(e('string(oai:setName/text())'))
+            setSpec = six.text_type(e('string(oai:setSpec/text())', namespaces=namespaces))
+            setName = six.text_type(e('string(oai:setName/text())', namespaces=namespaces))
             # XXX setDescription nodes
             sets.append((setSpec, setName, None))
         return sets, token
@@ -360,11 +360,11 @@ class Client(BaseClient):
 
 def buildHeader(header_node, namespaces):
     e = header_node.xpath
-    identifier = e('string(oai:identifier/text())')
+    identifier = e('string(oai:identifier/text())', namespaces=namespaces)
     datestamp = datestamp_to_datetime(
-        str(e('string(oai:datestamp/text())')))
-    setspec = [str(s) for s in e('oai:setSpec/text()')]
-    deleted = e("@status = 'deleted'")
+        str(e('string(oai:datestamp/text())', namespaces=namespaces)))
+    setspec = [str(s) for s in e('oai:setSpec/text()', namespaces=namespaces)]
+    deleted = e("@status = 'deleted'", namespaces=namespaces)
     return common.Header(header_node, identifier, datestamp, setspec, deleted)
 
 def ResumptionListGenerator(firstBatch, nextBatch):

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -335,7 +335,7 @@ class Client(BaseClient):
         self._local_file = local_file
         self._force_http_get = force_http_get
         if credentials is not None:
-            self._credentials = base64.encodestring('%s:%s' % credentials)
+            self._credentials = base64.encodebytes(credentials.encode()).decode()
         else:
             self._credentials = None
 

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -319,22 +319,32 @@ class BaseClient(common.OAIPMH):
 
 class Client(BaseClient):
 
-    def __init__(self, base_url, metadata_registry=None, credentials=None,
-                 local_file=False, force_http_get=False, custom_retry_policy=None):
-        BaseClient.__init__(self, metadata_registry,
-                            custom_retry_policy=custom_retry_policy)
+    def __init__(
+        self,
+        base_url,
+        metadata_registry=None,
+        credentials=None,
+        local_file=False,
+        force_http_get=False,
+        custom_retry_policy=None,
+        raw_data=None,
+    ):
+        BaseClient.__init__(
+            self, metadata_registry, custom_retry_policy=custom_retry_policy
+        )
         self._base_url = base_url
         self._local_file = local_file
         self._force_http_get = force_http_get
+        self._raw_data = raw_data
         if credentials is not None:
             self._credentials = base64.encodebytes(credentials.encode()).decode()
         else:
             self._credentials = None
 
     def makeRequest(self, **kw):
-        """Either load a local XML file or actually retrieve XML from a server.
-        """
-        if self._local_file:
+        if isinstance(self._raw_data, str):
+            return self._raw_data.encode('ascii', 'replace')
+        elif self._local_file:
             with codecs.open(self._base_url, 'r', 'utf-8') as xmlfile:
                 text = xmlfile.read()
             return text.encode('ascii', 'replace')

--- a/src/oaipmh/client.py
+++ b/src/oaipmh/client.py
@@ -39,7 +39,7 @@ class BaseClient(common.OAIPMH):
         'expected-errcodes': {503},
     }
 
-    def __init__(self, metadata_registry=None, custom_retry_policy=None):
+    def __init__(self, metadata_registry=None, custom_retry_policy=None, raw_data=None):
         self._metadata_registry = (
             metadata_registry or metadata.global_metadata_registry)
         self._ignore_bad_character_hack = 0
@@ -47,6 +47,7 @@ class BaseClient(common.OAIPMH):
         self.retry_policy = self.default_retry_policy.copy()
         if custom_retry_policy is not None:
             self.retry_policy.update(custom_retry_policy)
+        self._raw_data = raw_data
 
     def updateGranularity(self):
         """Update the granularity setting dependent on that the server says.
@@ -225,7 +226,7 @@ class BaseClient(common.OAIPMH):
             'string(/oai:OAI-PMH/*/oai:resumptionToken/text())',
             namespaces=namespaces
         )
-        if token.strip() == '':
+        if token.strip() == '' or self._raw_data:
             token = None
         record_nodes = tree.xpath('/oai:OAI-PMH/*/oai:record', namespaces=namespaces)
         result = []
@@ -330,12 +331,11 @@ class Client(BaseClient):
         raw_data=None,
     ):
         BaseClient.__init__(
-            self, metadata_registry, custom_retry_policy=custom_retry_policy
+            self, metadata_registry, custom_retry_policy=custom_retry_policy, raw_data=raw_data
         )
         self._base_url = base_url
         self._local_file = local_file
         self._force_http_get = force_http_get
-        self._raw_data = raw_data
         if credentials is not None:
             self._credentials = base64.encodebytes(credentials.encode()).decode()
         else:

--- a/src/oaipmh/common.py
+++ b/src/oaipmh/common.py
@@ -1,5 +1,3 @@
-import pkg_resources
-
 from oaipmh import error
 
 class Header(object):
@@ -49,7 +47,7 @@ class Metadata(object):
 class Identify(object):
     def __init__(self, repositoryName, baseURL, protocolVersion, adminEmails,
                  earliestDatestamp, deletedRecord, granularity, compression,
-                 toolkit_description=True):
+                 toolkit_description=False):
         self._repositoryName = repositoryName
         self._baseURL = baseURL
         self._protocolVersion = protocolVersion
@@ -59,8 +57,10 @@ class Identify(object):
         self._granularity = granularity
         self._compression = compression
         self._descriptions = []
-        
+
         if toolkit_description:
+            import pkg_resources
+
             req = pkg_resources.Requirement.parse('pyoai')
             egg = pkg_resources.working_set.find(req)
             if egg:
@@ -77,7 +77,7 @@ class Identify(object):
                 '%s'
                 '<URL>http://infrae.com/products/oaipack</URL>'
                 '</toolkit>' % version)
-        
+
     def repositoryName(self):
         return self._repositoryName
 

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -75,10 +75,6 @@ class MetadataReader(object):
                 # of lxml.etree._ElementUnicodeResult objects.
                 value = text_type(e(expr, namespace=self._namespaces))
             elif field_type == 'textList':
-                # make sure we get back unicode strings instead
-                # of lxml.etree._ElementUnicodeResult objects.
-                value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
-            elif field_type == 'textList':
                 # Make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
 

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -79,7 +79,7 @@ class MetadataReader(object):
                 # of lxml.etree._ElementUnicodeResult objects.
 
                 # Run the XPath query and get the result
-                result = e(expr, namespace=self._namespaces)
+                result = e(expr)
 
                 # Check if the result is a list. If not, treat it as a single item.
                 if isinstance(result, list):

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -75,6 +75,10 @@ class MetadataReader(object):
                 # of lxml.etree._ElementUnicodeResult objects.
                 value = text_type(e(expr, namespace=self._namespaces))
             elif field_type == 'textList':
+                # make sure we get back unicode strings instead
+                # of lxml.etree._ElementUnicodeResult objects.
+                value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
+            elif field_type == 'textList':
                 # Make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
 

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -78,23 +78,6 @@ class MetadataReader(object):
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
                 value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
-            elif field_type == 'textList':
-                # Make sure we get back unicode strings instead
-                # of lxml.etree._ElementUnicodeResult objects.
-
-                # Run the XPath query and get the result
-                result = e(expr, namespace=self._namespaces)
-
-                # Check if the result is a list. If not, treat it as a single item.
-                if isinstance(result, list):
-                    # The result is a list, so iterate and convert each element
-                    value = [text_type(v) for v in result]
-                elif result is not None:
-                    # The result is a single value, so wrap it in a list
-                    value = [text_type(result)]
-                else:
-                    # The result is None (e.g., no match), so return an empty list
-                    value = []
             else:
                 raise Error("Unknown field type: %s" % field_type)
             map[field_name] = value

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -63,45 +63,25 @@ class MetadataReader(object):
 
     def __call__(self, element):
         map = {}
-        # Alias for element.xpath
         e = element.xpath
+        # now extra field info according to xpath expr
         for field_name, (field_type, expr) in list(self._fields.items()):
-            try:
-                # The core logic is to safely handle the result from xpath()
-                raw_result = e(expr, namespaces=self._namespaces)
-
-                value = None
-                if field_type == 'bytes':
-                    value = str(raw_result)
-                elif field_type == 'bytesList':
-                    # Ensure the result is iterable before the list comprehension
-                    value = [str(item) for item in (raw_result if isinstance(raw_result, list) else [raw_result])]
-                elif field_type == 'text':
-                    value = text_type(raw_result)
-                elif field_type == 'textList':
-                    # This is the critical part to fix the error
-                    if isinstance(raw_result, list):
-                        # This handles the expected case: a list of elements/strings
-                        value = [text_type(v) for v in raw_result]
-                    elif raw_result is not None:
-                        # This handles a single value being returned
-                        value = [text_type(raw_result)]
-                    else:
-                        # Handles cases with no result (None)
-                        value = []
-                else:
-                    raise Error("Unknown field type: %s" % field_type)
-
-                map[field_name] = value
-
-            except Exception as ex:
-                # A robust way to prevent crashes
-                print(f"Warning: Error processing field '{field_name}' with expression '{expr}': {ex}", file=sys.stderr)
-                if field_type.endswith('List'):
-                    map[field_name] = []
-                else:
-                    map[field_name] = ""
-
+            if field_type == 'bytes':
+                value = str(e(expr, namespace=self._namespaces))
+            elif field_type == 'bytesList':
+                value = [str(item) for item in e(expr, namespace=self._namespaces)]
+            elif field_type == 'text':
+                # make sure we get back unicode strings instead
+                # of lxml.etree._ElementUnicodeResult objects.
+                value = text_type(e(expr, namespace=self._namespaces))
+            elif field_type == 'textList':
+                # make sure we get back unicode strings instead
+                # of lxml.etree._ElementUnicodeResult objects.
+                raise Exception(f"{element} - {expr} - {self._namespaces}")
+                value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
+            else:
+                raise Error("Unknown field type: %s" % field_type)
+            map[field_name] = value
         return common.Metadata(element, map)
 
 oai_dc_reader = MetadataReader(

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -63,25 +63,44 @@ class MetadataReader(object):
 
     def __call__(self, element):
         map = {}
+        # Alias for element.xpath
         e = element.xpath
-        # now extra field info according to xpath expr
         for field_name, (field_type, expr) in list(self._fields.items()):
-            if field_type == 'bytes':
-                value = str(e(expr, namespace=self._namespaces))
-            elif field_type == 'bytesList':
-                value = [str(item) for item in e(expr, namespace=self._namespaces)]
-            elif field_type == 'text':
-                # make sure we get back unicode strings instead
-                # of lxml.etree._ElementUnicodeResult objects.
-                value = text_type(e(expr, namespace=self._namespaces))
-            elif field_type == 'textList':
-                # make sure we get back unicode strings instead
-                # of lxml.etree._ElementUnicodeResult objects.
-                raise Exception(f"{element} - {expr} - {self._namespaces}")
-                value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
-            else:
-                raise Error("Unknown field type: %s" % field_type)
-            map[field_name] = value
+            try:
+                # The core logic is to safely handle the result from xpath()
+                raw_result = e(expr, namespaces=self._namespaces)
+
+                value = None
+                if field_type == 'bytes':
+                    value = str(raw_result)
+                elif field_type == 'bytesList':
+                    # Ensure the result is iterable before the list comprehension
+                    value = [str(item) for item in (raw_result if isinstance(raw_result, list) else [raw_result])]
+                elif field_type == 'text':
+                    value = text_type(raw_result)
+                elif field_type == 'textList':
+                    # This is the critical part to fix the error
+                    if isinstance(raw_result, list):
+                        # This handles the expected case: a list of elements/strings
+                        value = [text_type(v) for v in raw_result]
+                    elif raw_result is not None:
+                        # This handles a single value being returned
+                        value = [text_type(raw_result)]
+                    else:
+                        # Handles cases with no result (None)
+                        value = []
+                else:
+                    raise Error("Unknown field type: %s" % field_type)
+
+                map[field_name] = value
+            except Exception as ex:
+                # A robust way to prevent crashes
+                print(f"Warning: Error processing field '{field_name}' with expression '{expr}': {ex}", file=sys.stderr)
+                if field_type.endswith('List'):
+                    map[field_name] = []
+                else:
+                    map[field_name] = ""
+
         return common.Metadata(element, map)
 
 oai_dc_reader = MetadataReader(

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -1,7 +1,5 @@
 import sys
 
-from lxml import etree
-from lxml.etree import SubElement
 from oaipmh import common
 
 if sys.version_info[0] == 3:
@@ -21,7 +19,7 @@ class MetadataRegistry(object):
     def __init__(self):
         self._readers = {}
         self._writers = {}
-        
+
     def registerReader(self, metadata_prefix, reader):
         self._readers[metadata_prefix] = reader
 
@@ -30,10 +28,10 @@ class MetadataRegistry(object):
 
     def hasReader(self, metadata_prefix):
         return metadata_prefix in self._readers
-    
+
     def hasWriter(self, metadata_prefix):
         return metadata_prefix in self._writers
-    
+
     def readMetadata(self, metadata_prefix, element):
         """Turn XML into metadata object.
 
@@ -45,7 +43,7 @@ class MetadataRegistry(object):
 
     def writeMetadata(self, metadata_prefix, element, metadata):
         """Write metadata as XML.
-        
+
         element - ElementTree element to write under
         metadata - metadata object to write
         """
@@ -65,11 +63,7 @@ class MetadataReader(object):
 
     def __call__(self, element):
         map = {}
-        # create XPathEvaluator for this element
-        xpath_evaluator = etree.XPathEvaluator(element, 
-                                               namespaces=self._namespaces)
-        
-        e = xpath_evaluator.evaluate
+        e = element.xpath
         # now extra field info according to xpath expr
         for field_name, (field_type, expr) in list(self._fields.items()):
             if field_type == 'bytes':
@@ -111,6 +105,3 @@ oai_dc_reader = MetadataReader(
     'oai_dc': 'http://www.openarchives.org/OAI/2.0/oai_dc/',
     'dc' : 'http://purl.org/dc/elements/1.1/'}
     )
-
-
-    

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -77,6 +77,7 @@ class MetadataReader(object):
             elif field_type == 'textList':
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
+                raise Exception(f"{element} - {expr} - {self._namespaces}")
                 value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
             else:
                 raise Error("Unknown field type: %s" % field_type)

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -78,6 +78,23 @@ class MetadataReader(object):
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
                 value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
+            elif field_type == 'textList':
+                # Make sure we get back unicode strings instead
+                # of lxml.etree._ElementUnicodeResult objects.
+
+                # Run the XPath query and get the result
+                result = e(expr, namespace=self._namespaces)
+
+                # Check if the result is a list. If not, treat it as a single item.
+                if isinstance(result, list):
+                    # The result is a list, so iterate and convert each element
+                    value = [text_type(v) for v in result]
+                elif result is not None:
+                    # The result is a single value, so wrap it in a list
+                    value = [text_type(result)]
+                else:
+                    # The result is None (e.g., no match), so return an empty list
+                    value = []
             else:
                 raise Error("Unknown field type: %s" % field_type)
             map[field_name] = value

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -67,17 +67,17 @@ class MetadataReader(object):
         # now extra field info according to xpath expr
         for field_name, (field_type, expr) in list(self._fields.items()):
             if field_type == 'bytes':
-                value = str(e(expr))
+                value = str(e(expr, namespace=self._namespaces))
             elif field_type == 'bytesList':
-                value = [str(item) for item in e(expr)]
+                value = [str(item) for item in e(expr, namespace=self._namespaces)]
             elif field_type == 'text':
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
-                value = text_type(e(expr))
+                value = text_type(e(expr, namespace=self._namespaces))
             elif field_type == 'textList':
                 # make sure we get back unicode strings instead
                 # of lxml.etree._ElementUnicodeResult objects.
-                value = [text_type(v) for v in e(expr)]
+                value = [text_type(v) for v in e(expr, namespace=self._namespaces)]
             else:
                 raise Error("Unknown field type: %s" % field_type)
             map[field_name] = value

--- a/src/oaipmh/metadata.py
+++ b/src/oaipmh/metadata.py
@@ -79,7 +79,7 @@ class MetadataReader(object):
                 # of lxml.etree._ElementUnicodeResult objects.
 
                 # Run the XPath query and get the result
-                result = e(expr)
+                result = e(expr, namespace=self._namespaces)
 
                 # Check if the result is a list. If not, treat it as a single item.
                 if isinstance(result, list):


### PR DESCRIPTION
`base64.encodestring` was deprecated around python v3.1 I think, and got completely removed since python v3.9.

I also set `toolkit_description` to `False` by default and put `import pkg_resources` within the condition to prevent it from being loaded. That package is deprecated/removed since python v3.12.

Finally, get rid of all evaluators and other regressions with latest lxml package.

In addition to those fixes, I also added support processing `raw_data` next to the already supported network call and local file processing options.